### PR TITLE
自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -48,16 +48,7 @@ $(function(){
     });
   });
   
-
-
-　　　　　　//以下は自動更新の記述
-
-
-
-
-
-
-
+               //以下は自動更新の記述
     var reloadMessages = function() {
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
       var last_message_id = $('.message:last').data("message-id");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -19,28 +19,36 @@ function buildHTML(message) {
 
   return html;       
 }
-$('#new_message').on('submit', function(e){
-  e.preventDefault();
-  var formData = new FormData(this);
-  var url = $(this).attr('action')
-  $.ajax({
-    url: url,
-    type: "POST",
-    data: formData,
-    dataType: 'json',
-    processData: false,
-    contentType: false
-  })
-.done(function(data){ 
-  var html = buildHTML(data);
-  $('.messages').append(html);
-    $("form")[0].reset();
-    $('input').prop('disabled', false);
-    $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
-  })
-.fail(function() {
-  alert("メッセージ送信に失敗しました");
-  });
+
+
+
+$(function(){
+  var reloadMessages = function(){  //自動更新の関数
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){ //今いるページのリンクが/groups/グループid/messagesであれば以下を実行
+      var last_message_id = $('.message:last').data("message-id"); //dataメソッドで.messageにある:last(最後)のカスタムデータ属性を取得しlast_message_idに代入
+      $.ajax({
+        url: "api/messages", //サーバの指定(api/message_controller)
+        type: 'get', //メソッド(get)
+        dataType: 'json', //データの形式(json)
+        data: {id: last_message_id} //飛ばすデータ(取得したlast_message_id)
+      })
+      .done(function(messages){ //自動更新成功の時の処理(controllerから受け取ったmessageを引数にする)
+        var insertHTML = ''; //HTMLの入れ物
+        messages.forEach(function(message){ //配列messagesの中身一つ一つをHTMLに変換して入れ物に足し合わせる
+          insertHTML = buildHTML(message); //メッセージが入ったHTMLを取得 
+          $(".messages").append(insertHTML); //メッセージを追加
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 50); //自動更新が成功した時(メッセージが送信できた時)のみ一番下までスクロールする
+        })
+      })
+
+      .fail(function(){ //自動更新が失敗した時の処理
+        alert('自動更新に失敗しました'); //アラートを出す
+      });
+    }
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000); //7000ミリ秒(7秒)ごとにreloadMessages(自動更新の関数)を実行
+});
 });
 
 //id属性はブラウザの検証を利用するとわかる。 new_messageと書いてある。

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,55 +1,98 @@
-function buildHTML(message) {
-  var image = message.image ?`<img src= "${message.image}">`:""; 
-  var html = `<div class ="message" data-message-id="${message.id}">
-                <div class ="upper-message">
-                  <div class ="upper-message__user-name">
+$(function(){
+
+  function buildHTML(message){
+    image = ( message.image ) ? `<img class="lower-message__image" src=${message.image} >` : ""; //三項演算子
+                var html =  
+                ` <div class="message" data-message-id="${message.id}">
+                <div class="upper-message">
+                  <div class="upper-message__user-name">
                     ${message.user_name}
                   </div>
-                  <div class ="upper-message__date">
+                  <div class="upper-message__date">
                     ${message.date}
                   </div>
                 </div>
-                <div class ="text-message">
-                  <p class ="text-message__content">
-                      ${content}
+                <div class="lower-message">
+                  <p class="lower-message__content">
+                  ${message.content}
                   </p>
-                      ${image}
+                  ${image}
                 </div>
               </div>`
-
-  return html;       
-}
-
+          return html; 
+  }
 
 
-$(function(){
-  var reloadMessages = function(){  //自動更新の関数
-    if (window.location.href.match(/\/groups\/\d+\/messages/)){ //今いるページのリンクが/groups/グループid/messagesであれば以下を実行
-      var last_message_id = $('.message:last').data("message-id"); //dataメソッドで.messageにある:last(最後)のカスタムデータ属性を取得しlast_message_idに代入
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $("form")[0].reset();
+      $('input').prop('disabled', false);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 50);
+    })
+      .fail(function() {
+        alert("メッセージ送信に失敗しました");
+    });
+  });
+  
+
+
+　　　　　　//以下は自動更新の記述
+
+
+
+
+
+
+
+    var reloadMessages = function() {
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      var last_message_id = $('.message:last').data("message-id");
       $.ajax({
-        url: "api/messages", //サーバの指定(api/message_controller)
-        type: 'get', //メソッド(get)
-        dataType: 'json', //データの形式(json)
-        data: {id: last_message_id} //飛ばすデータ(取得したlast_message_id)
+        //ルーティングで設定した通りのURLを指定
+        url: "api/messages",
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
       })
-      .done(function(messages){ //自動更新成功の時の処理(controllerから受け取ったmessageを引数にする)
-        var insertHTML = ''; //HTMLの入れ物
-        messages.forEach(function(message){ //配列messagesの中身一つ一つをHTMLに変換して入れ物に足し合わせる
-          insertHTML = buildHTML(message); //メッセージが入ったHTMLを取得 
-          $(".messages").append(insertHTML); //メッセージを追加
-          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 50); //自動更新が成功した時(メッセージが送信できた時)のみ一番下までスクロールする
-        })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
       })
-
-      .fail(function(){ //自動更新が失敗した時の処理
-        alert('自動更新に失敗しました'); //アラートを出す
+      .fail(function() {
+        alert('error');
       });
-    }
-  };
+    };
+  
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {
-    setInterval(reloadMessages, 7000); //7000ミリ秒(7秒)ごとにreloadMessages(自動更新の関数)を実行
-});
-});
+    setInterval(reloadMessages, 7000);    // 引数で渡している7000という数字は、7秒という意味
+  }   
+
+  });
+
+
+
 
 //id属性はブラウザの検証を利用するとわかる。 new_messageと書いてある。
 // 「console.log()」は何らかの文字列を出力するためのメソッド

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -111,7 +111,7 @@
   right: 40px;
  }
 
-.massages{
+.messages{
   height: calc(100vh - 190px);
   padding: 46px 40px;
   background-color: #fafafa;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -8,3 +8,4 @@ class Api::MessagesController < ApplicationController
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end
+

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -12,7 +12,7 @@
       = link_to 'Edit', edit_group_path(@group)
       -# メッセージコントローラーの@group = Group.find(params[:group_id])が書かれている。
       
-  .massages
+  .messages
     = render @messages
     -# renderメソッドは、部分テンプレートを呼び出す際に利用するメソッド
     -# 部分テンプレートのファイル名は必ずアンダーバー「_」から始まる

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,5 @@
 .message
+  .message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,4 @@
-.message
-  .message{data: {message: {id: message.id}}}
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,5 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+#idもデータとして渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,16 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]    # インクリメンタルサーチを実装の為、indexアクションを追記
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do   #  namespace :ディレクトリ名 do ~ endと囲む形でルーティングを記述すると、そのディレクトリ内のコントローラのアクションを指定出来る。
+      resources :messages, only: :index, defaults: { format: 'json' }   # defaultsオプション = このルーティングが来たらjson形式でレスポンスするよう指定
+    end
   end
 end
+
+
+
+
+
+#自動生成されたルートを確認
+# $ rails routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,5 @@ Rails.application.routes.draw do
   end
 end
 
-
-
-
-
 #自動生成されたルートを確認
 # $ rails routes


### PR DESCRIPTION
#what
chatspaceに自動更新機能を追加した
自動更新機能を追加することでリロードをすることなく新規メッセージを取得することができる。自動更新機能を追加するに際には新たにルーティング、コントローラー、jbuilderを追加し対応するアクションなどを追加した。
#why
自動更新機能はchatspaceでのコミュニケーションを円滑に進めるために必要な機能のため。